### PR TITLE
Configured JaCoCo code coverage for project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'com.technokratos.jacoco-convention'
+}
+
 subprojects {
     group = 'com.technokratos.eateasy'
     version = '1.0-SNAPSHOT'
@@ -15,5 +19,3 @@ subprojects {
         }
     }
 }
-
-

--- a/buildSrc/src/main/groovy/com/technokratos/eateasy/JacocoConventionPlugin.groovy
+++ b/buildSrc/src/main/groovy/com/technokratos/eateasy/JacocoConventionPlugin.groovy
@@ -1,0 +1,102 @@
+package com.technokratos.eateasy
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class JacocoConventionPlugin implements Plugin<Project> {
+
+    private static final String[] EXCLUDE = [
+            '**/dto/**',
+            '**/exception/**',
+            '**/*Exception.class'
+    ]
+
+    private static final String[] INCLUDE = [
+            "**/*.class"
+    ]
+
+    private static final Float MINIMUM_COVERAGE = 0.8
+
+    @Override
+    void apply(Project rootProject) {
+        rootProject.subprojects { Project subproject ->
+            if (hasJavaSources(subproject)) {
+                configureForJavaProject(subproject)
+            } else {
+                configureForNonJavaProject(subproject)
+            }
+        }
+
+        registerAggregatedCheckTask(rootProject)
+    }
+
+    private void configureForJavaProject(Project project) {
+        project.with {
+            apply plugin: 'jacoco'
+            jacoco {
+                toolVersion = '0.8.13'
+            }
+
+            afterEvaluate {
+                tasks.named('jacocoTestReport') {
+                    reports {
+                        xml.required = true
+                        html.required = true
+                    }
+
+                    classDirectories.setFrom(files(classDirectories.files.collect {
+                        fileTree(dir: it,
+                                include: INCLUDE,
+                                exclude: EXCLUDE
+                        )
+                    }))
+
+                    dependsOn tasks.named('test')
+                    mustRunAfter tasks.named('test')
+                }
+
+                tasks.named('jacocoTestCoverageVerification') {
+                    violationRules {
+                        rule {
+                            limit {
+                                counter = 'LINE'
+                                minimum = MINIMUM_COVERAGE
+                            }
+                        }
+
+                        rule {
+                            limit {
+                                counter = 'BRANCH'
+                                minimum = MINIMUM_COVERAGE
+                            }
+                        }
+                    }
+                }
+
+                tasks.named('check') {
+                    dependsOn tasks.named('jacocoTestCoverageVerification')
+                }
+
+                tasks.named('test') {
+                    finalizedBy tasks.named('jacocoTestReport')
+                }
+            }
+        }
+    }
+
+    private void configureForNonJavaProject(Project project) {
+        registerAggregatedCheckTask(project)
+    }
+
+    private void registerAggregatedCheckTask(Project project) {
+        project.tasks.register('check') {
+            dependsOn project.subprojects*.tasks*.named('check')
+            description = "Aggregates check tasks of all subprojects"
+            group = "verification"
+        }
+    }
+
+    private static boolean hasJavaSources(Project project) {
+        return project.file("${project.projectDir}/src/main/java").exists()
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/com.technokratos.jacoco-convention.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/com.technokratos.jacoco-convention.properties
@@ -1,0 +1,1 @@
+implementation-class=com.technokratos.eateasy.JacocoConventionPlugin


### PR DESCRIPTION
- Implement JacocoConventionPlugin that automatically configures Jacoco

- Set minimum coverage thresholds (80% for lines and branches)

- Exclude packages `**.dto.**`, `**.exception.**` and classes ends with "Exception" from coverage